### PR TITLE
Team Server changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+team-server/changelog/changelog.md

--- a/team-server/changelog/releases/0.2.3/dataset-import-fix.yaml
+++ b/team-server/changelog/releases/0.2.3/dataset-import-fix.yaml
@@ -1,0 +1,4 @@
+prLink: "https://github.com/gigantum/self-hosted/pull/28"
+changelog:
+  - type: FIX
+    description: Fixed missing import in the dataset service that caused errors in dataset uploads when using external storage

--- a/team-server/changelog/render.py
+++ b/team-server/changelog/render.py
@@ -1,0 +1,95 @@
+import glob
+import json
+import argparse
+import yaml
+from natsort import natsorted
+import requests
+from pathlib import Path
+from collections import OrderedDict
+from datetime import date
+
+
+def get_current_release_dir() -> str:
+    """Get the directory to the current release
+    Returns:
+    """
+    releases = list()
+    for release in glob.glob("./releases/*"):
+        releases.append(release)
+
+    releases = natsorted(releases)
+
+    return releases[-1]
+
+
+def generate_changelog() -> OrderedDict:
+    """Method to generate the changelog data structure as an OrderedDict
+    Returns:
+        OrderedDict
+    """
+    latest_version_dir = get_current_release_dir()
+
+    messages = list()
+    changes = dict()
+    for changelog_file in glob.glob(f"{latest_version_dir}/*.yaml"):
+        contents = yaml.safe_load(Path(changelog_file).read_bytes())
+
+        _, pr_number = contents['prLink'].rsplit('/', 1)
+
+        if 'message' in contents:
+            messages.append(contents['message'])
+
+        for item in contents['changelog']:
+            if item['type'] == "NON_USER_FACING":
+                continue
+
+            changes.setdefault(item['type'], []).append(f"{item['description']} (#{pr_number})")
+
+    if len(messages) == 0:
+        # legacy code requires an empty message string if no messages.
+        messages.append("")
+
+    # Add to existing file
+    data = OrderedDict()
+    data["date"] = str(date.today())
+    data["changes"] = changes
+    data["messages"] = messages
+    _, data["version"] = latest_version_dir.rsplit("/", 1)
+
+    return data
+
+
+def render_markdown(output_dir: str) -> None:
+    """Render the changelog data to a markdown file.
+    Args:
+        output_dir: directory to write file
+    Returns:
+        None
+    """
+    data = generate_changelog()
+    md = ""
+
+    md = md + f"## {data['date']}\n\n"
+    md = md + f"### Team Server ({data['version']})\n\n"
+
+    for section in data['changes']:
+        md = md + f"* **{section}**\n"
+        for change in data['changes'][section]:
+            md = md + f"  * {change}\n"
+
+        md = md + "\n"
+
+    md = md + "\n\n"
+
+    Path(Path(output_dir).expanduser().absolute(), 'changelog.md').write_text(md)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # Required positional argument
+    parser.add_argument("--directory", '-d', default='.', help="Desired output directory.")
+
+    args = parser.parse_args()
+
+    render_markdown(args.directory)

--- a/team-server/changelog/requirements.txt
+++ b/team-server/changelog/requirements.txt
@@ -1,0 +1,4 @@
+yamale==2.2.0
+pyyaml==5.4.1
+natsort==7.0.1
+requests==2.23.0

--- a/team-server/changelog/schema.yaml
+++ b/team-server/changelog/schema.yaml
@@ -1,0 +1,14 @@
+message: str(required=False)
+prLink: str(required=True)
+changelog: list(include('changelog_item'))
+
+
+
+---
+changelog_item:
+  type: enum('NEW', 'IMPROVEMENT', 'FIX', 'NON_USER_FACING', 'DEPENDENCY_CHANGE', 'REMOVED', 'DEPRECATED')
+  description: str(required=True)
+  issueLink: str(required=False)
+  dependencyOwner: str(required=False)
+  dependencyRepo: str(required=False)
+  dependencyTag: str(required=False)

--- a/team-server/changelog/validate.py
+++ b/team-server/changelog/validate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import glob
+import yamale
+import argparse
+import os
+from pathlib import Path
+import yaml
+
+
+def validate_schema() -> None:
+    """Method to validate all changelog yaml files using the defined schema`
+
+    Returns:
+        None
+    """
+    print("Validating changelog files.")
+    schema = yamale.make_schema('./schema.yaml')
+
+    for changelog_file in glob.glob("./releases/*/*.yaml"):
+        data = yamale.make_data(changelog_file)
+        yamale.validate(schema, data)
+
+    print("All changelog files valid.")
+
+
+def verify_pr_contains_changelog() -> None:
+    """Method to check if the current PR contains a changelog yaml file. This is done by searching through all the
+    files for one that contains `prLink == CIRCLE_PULL_REQUEST`, where CIRCLE_PULL_REQUEST is the URL to the
+    PR in github, automatically set by circleCI
+
+    Returns:
+        None
+    """
+    print("Searching for changelog file associated with this PR.")
+
+    pr_under_test = os.environ.get('CIRCLE_PULL_REQUEST')
+    if pr_under_test is None:
+        raise Exception("Failed to get current PR URL from CIRCLE_PULL_REQUEST env var.")
+
+    for changelog_file in glob.glob("./releases/*/*.yaml"):
+        data = yaml.safe_load(Path(changelog_file).read_bytes())
+        if data.get('prLink') == pr_under_test:
+            print(f"Found changelog entry for this PR: {changelog_file}")
+            return
+
+    raise Exception("No changelog found for this PR. Please add changelog details for this PR before merging.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    # Required positional argument
+    parser.add_argument("action", help="Desired action to run. (`schema` or `pr`)")
+
+    args = parser.parse_args()
+
+    if args.action == "schema":
+        validate_schema()
+    elif args.action == "pr":
+        verify_pr_contains_changelog()
+    else:
+        raise ValueError(f"Unsupported action: {args.action}")


### PR DESCRIPTION
Added Team Server changelog code including the updates for stable/0.2.3 (already merged). Team Server's changelog code is kept here instead of the `self-hosted` repo to ensure the yamls don't get included in flux's attempted deployments, but could get moved back to `self-hosted` if we update that repo to move all manifests one level up from root, and update `gigactl` to point flux at this folder instead of root.